### PR TITLE
feat: add impure mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
+ "subst",
 ]
 
 [[package]]
@@ -453,6 +454,16 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subst"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9a86e5144f63c2d18334698269a8bfae6eece345c70b64821ea5b35054ec99"
+dependencies = [
+ "memchr",
+ "unicode-width",
+]
 
 [[package]]
 name = "syn"
@@ -562,6 +573,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ log = "0.4.27"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 simplelog = "0.12.2"
+subst = "0.3.8"
 
 [profile.release]
 strip = true

--- a/src/args.rs
+++ b/src/args.rs
@@ -10,6 +10,13 @@ pub struct Args {
     #[arg(short, long)]
     pub verbose: bool,
 
+    #[arg(
+        long,
+        default_value = "false",
+        help = "Allows use of relative paths and environment variable substitutions in paths"
+    )]
+    pub impure: bool,
+
     #[command(subcommand)]
     pub sub_command: Subcommands,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,12 +39,15 @@ fn main() {
 
     info!("Program version: '{VERSION}'");
     match args.sub_command {
-        Subcommands::Deactivate { manifest } => Manifest::read(&manifest).deactivate(),
-        Subcommands::Activate { manifest, prefix } => Manifest::read(&manifest).activate(&prefix),
+        Subcommands::Deactivate { manifest } => Manifest::read(&manifest, args.impure).deactivate(),
+        Subcommands::Activate { manifest, prefix } => {
+            Manifest::read(&manifest, args.impure).activate(&prefix);
+        }
         Subcommands::Diff {
             prefix,
             manifest,
             old_manifest,
-        } => Manifest::read(&manifest).diff(Manifest::read(&old_manifest), &prefix),
+        } => Manifest::read(&manifest, args.impure)
+            .diff(Manifest::read(&old_manifest, args.impure), &prefix),
     }
 }


### PR DESCRIPTION
This mode allows use of environment variables, ~ shorthand, and relative referencing in source or target paths.